### PR TITLE
checkstyle: Add option to suppress warnings with @SuppressWarnings

### DIFF
--- a/code-quality/checkstyle.xml
+++ b/code-quality/checkstyle.xml
@@ -38,7 +38,10 @@
     <property name="eachLine" value="true"/>
   </module>
 
+  <module name="SuppressWarningsFilter" />
+
   <module name="TreeWalker">
+    <module name="SuppressWarningsHolder" />
     <module name="FileContentsHolder"/>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">


### PR DESCRIPTION
For these rare cases where you *know* you know better than the style checker.

```java
@SuppressWarnings("checkstyle:methodlength")
@Override
public boolean equals(Object obj) {
    // very long auto-generated equals() method
}
```