### PR TITLE
CI: Generic configuration

### DIFF
--- a/ci/.gitlab-ci-base.yml
+++ b/ci/.gitlab-ci-base.yml
@@ -1,0 +1,56 @@
+image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK"
+
+variables:
+  MAVEN_CLI_OPTS: "--batch-mode"
+
+.set_env_variables: &set_env_variables
+  - PROJECT_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml)
+
+stages:
+  - build
+  - test
+
+cache:
+  key: "$CI_COMMIT_SHA"
+  paths:
+    - target/
+
+###################
+### Stage build ###
+###################
+
+.compile:
+  before_script: *set_env_variables
+  script:
+    - echo "Compiling version $PROJECT_VERSION"
+    - mvn $MAVEN_CLI_OPTS -U clean install
+  stage: build
+
+compile:
+  extends: .compile
+
+compile:openjdk11:
+  extends: .compile
+  image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
+  variables:
+    JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"
+
+##################
+### Stage test ###
+##################
+
+.verify:
+  dependencies:
+    - compile
+    - compile:openjdk11
+  script: mvn $MAVEN_CLI_OPTS verify
+  stage: test
+
+verify:
+  extends: .verify
+
+verify:openjdk11:
+  extends: .verify
+  image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
+  variables:
+    JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,29 @@
+# `.gitlab-ci.yml` skeleton
+
+The `.gitlab-ci-base.yml` configuration is a skeleton for a generic GitLab CI 
+configuration that can be included in various repositories.
+
+# Usage
+
+This generic GitLab CI configuration can be included in a project-specific
+GitLab CI configuration via:
+
+```yml
+include: "https://raw.githubusercontent.com/dbmdz/development/master/ci/gitlab-ci-base.yml"
+```
+
+# Variables
+
+The following GitLab CI environment variables needs to be set:
+
+| Variable                          | Description
+| --------------------------------- | -----------
+| `BUILD_IMAGE_ANSIBLE_MAVEN_JDK`   | Name of OpenJDK 8 Docker Image
+| `BUILD_IMAGE_ANSIBLE_MAVEN_JDK11` | Name of OpenJDK 11 Docker Image
+
+# Limitations
+
+Known limitations are:
+
+* Sonar checks are currently not supported
+* Publishing snapshots or releases to Nexus are not supported

--- a/ci/README.md
+++ b/ci/README.md
@@ -25,5 +25,4 @@ The following GitLab CI environment variables needs to be set:
 
 Known limitations are:
 
-* Sonar checks are currently not supported
-* Publishing snapshots or releases to Nexus are not supported
+* Publishing snapshots to Sonatype Nexus and releases to GitHub


### PR DESCRIPTION
This PR adds documentation and implementation for a generic GitLab CI configuration.

We are going to use this skeleton for further builds.

All Open Source projects on GitHub.com should use GitLab.com CI and Runner for continuous integration. This PR is a first step to replace Travis CI.