### PR TITLE
Generic CI Configuration

### DIFF
--- a/ci/.gitlab-ci-base.yml
+++ b/ci/.gitlab-ci-base.yml
@@ -56,6 +56,13 @@ verify:openjdk11:
   variables:
     JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"
 
+verifiy_codecov:
+  only:
+    variables:
+      - $CODECOV_TOKEN
+  script: bash <(curl -s https://codecov.io/bash)
+  stage: test
+
 #####################
 ### Stage publish ###
 #####################

--- a/ci/.gitlab-ci-base.yml
+++ b/ci/.gitlab-ci-base.yml
@@ -10,6 +10,7 @@ stages:
   - build
   - test
   - publish
+  - release
 
 cache:
   key: "$CI_COMMIT_SHA"
@@ -91,3 +92,29 @@ publish_release:
   script:
     - if [[ "$PROJECT_VERSION" =~ .*SNAPSHOT ]]; then exit 0; fi
     - mvn $MAVEN_CLI_OPTS -fn -T 4 deploy --settings settings.xml
+
+#####################
+### Stage release ###
+#####################
+
+.release:
+  before_script: *set_env_variables
+  dependencies:
+    - publish_release
+  stage: release
+
+github_release:
+  extends: .release
+  only:
+    - tags
+  script:
+    - if [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
+    - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.jar" -exec echo -a {} \;) -t $CI_COMMIT_SHA $CI_COMMIT_TAG
+
+github_prelease:
+  extends: .release
+  only:
+    - tags
+  script:
+    - if ! [[ "$CI_COMMIT_TAG" =~ .*RC.* ]]; then exit 0; fi
+    - hub release create -m $CI_COMMIT_TAG $(find . -iname "*.jar" -exec echo -a {} \;) -p -t $CI_COMMIT_SHA $CI_COMMIT_TAG

--- a/ci/.gitlab-ci-base.yml
+++ b/ci/.gitlab-ci-base.yml
@@ -98,7 +98,9 @@ publish_release:
 #####################
 
 .release:
-  before_script: *set_env_variables
+  before_script:
+    - git remote rm origin
+    - git remote add origin "https://github.com/$CI_PROJECT_PATH.git"
   dependencies:
     - publish_release
   stage: release

--- a/ci/.gitlab-ci-base.yml
+++ b/ci/.gitlab-ci-base.yml
@@ -1,0 +1,56 @@
+image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK"
+
+variables:
+  MAVEN_CLI_OPTS: "--batch-mode"
+
+.set_env_variables: &set_env_variables
+  - PROJECT_VERSION=$(xmllint --xpath '/*[local-name()="project"]/*[local-name()="version"]/text()' pom.xml)
+
+stages:
+  - build
+  - test
+
+cache:
+  key: "$CI_COMMIT_SHA"
+  paths:
+    - target/
+
+###################
+### Stage build ###
+###################
+
+.compile:
+  before_script: *set_env_variables
+  script:
+    - echo "Compiling version $PROJECT_VERSION"
+    - mvn $MAVEN_CLI_OPTS -U clean install
+  stage: build
+
+compile:
+  extends: .compile
+
+compile:openjdk11:
+  extends: .compile
+  image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
+  variables:
+    JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"
+
+##################
+### Stage test ###
+##################
+
+.verify:
+  dependencies:
+    - compile
+    - compile:openjdk11
+  script: mvn $MAVEN_CLI_OPTS verify
+  stage: test
+
+verify:
+  extends: .verify
+
+verify:openjdk11:
+  extends: .verify
+  image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
+  variables:
+    JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"

--- a/ci/.gitlab-ci-base.yml
+++ b/ci/.gitlab-ci-base.yml
@@ -9,6 +9,7 @@ variables:
 stages:
   - build
   - test
+  - publish
 
 cache:
   key: "$CI_COMMIT_SHA"
@@ -54,3 +55,32 @@ verify:openjdk11:
   image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
   variables:
     JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"
+
+#####################
+### Stage publish ###
+#####################
+
+.publish:
+  before_script: *set_env_variables
+  dependencies:
+    - verify
+  except:
+    variables:
+      - $NO_PUBLISH
+  stage: publish
+
+publish_snapshot:
+  extends: .publish
+  only:
+    - master
+  script:
+    - if [[ ! "$PROJECT_VERSION" =~ .*SNAPSHOT ]]; then exit 0; fi
+    - mvn $MAVEN_CLI_OPTS -T 4 deploy --settings settings.xml
+
+publish_release:
+  extends: .publish
+  only:
+    - tags
+  script:
+    - if [[ "$PROJECT_VERSION" =~ .*SNAPSHOT ]]; then exit 0; fi
+    - mvn $MAVEN_CLI_OPTS -fn -T 4 deploy --settings settings.xml

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,29 @@
+# `.gitlab-ci.yml` skeleton
+
+The `.gitlab-ci-base.yml` configuration is a skeleton for a generic GitLab CI 
+configuration that can be included in various repositories.
+
+# Usage
+
+This generic GitLab CI configuration can be included in a project-specific
+GitLab CI configuration via:
+
+```yml
+include: "https://raw.githubusercontent.com/dbmdz/development/master/ci/gitlab-ci-base.yml"
+```
+
+# Variables
+
+The following GitLab CI environment variables needs to be set:
+
+| Variable                          | Description
+| --------------------------------- | -----------
+| `BUILD_IMAGE_ANSIBLE_MAVEN_JDK`   | Name of OpenJDK 8 Docker Image
+| `BUILD_IMAGE_ANSIBLE_MAVEN_JDK11` | Name of OpenJDK 11 Docker Image
+
+# Limitations
+
+Known limitations are:
+
+* Sonar checks are currently not supported
+* Publishing snapshots or releases to Nexus are not supported

--- a/ci/README.md
+++ b/ci/README.md
@@ -25,5 +25,4 @@ The following GitLab CI environment variables needs to be set:
 
 Known limitations are:
 
-* Sonar checks are currently not supported
-* Publishing snapshots or releases to Nexus are not supported
+* Publishing snapshots to Sonatype Nexus and releases to GitHub

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,7 +1,8 @@
 # `.gitlab-ci.yml` skeleton
 
-The `.gitlab-ci-base.yml` configuration is a skeleton for a generic GitLab CI 
-configuration that can be included in various repositories.
+The `.gitlab-ci-base.yml` configuration is a skeleton for generic GitLab CI
+configuration that can be included in various repositories. It is currently
+used at @dbmdz to build our Open Source projects on GitHub.
 
 # Usage
 
@@ -16,13 +17,22 @@ include: "https://raw.githubusercontent.com/dbmdz/development/master/ci/gitlab-c
 
 The following GitLab CI environment variables needs to be set:
 
+## Group variables
+
 | Variable                          | Description
-| --------------------------------- | -----------
+| --------------------------------- | -------------------------------
 | `BUILD_IMAGE_ANSIBLE_MAVEN_JDK`   | Name of OpenJDK 8 Docker Image
 | `BUILD_IMAGE_ANSIBLE_MAVEN_JDK11` | Name of OpenJDK 11 Docker Image
+| `SONATYPE_USERNAME`               | Username of Sonatype Repository
+| `SONATYPE_PASSWORD`               | Password of Sonatype Repository
 
-# Limitations
+## Repository-wise variables
 
-Known limitations are:
+Each repository should define the following variables:
 
-* Publishing snapshots to Sonatype Nexus and releases to GitHub
+| Variable                          | Description
+| --------------------------------- | ---------------------
+| `CODECOV_TOKEN`                   | Token for Codecov API
+
+If the environment variable `NO_PUBLISH` is set, then deploying artifacts to
+Sonatype is disabled.


### PR DESCRIPTION
This PR adds a Generic CI Configuration for building our Open Source projects with GitLab.

This Generic CI Configuration allows us to perform builds with our own GitLab CI Runner.

Thus, we can remove Travis CI dependencies from our projects.