### PR TITLE
Remove OverloadMethodsDeclarationOrder

### DIFF
--- a/code-quality/checkstyle.xml
+++ b/code-quality/checkstyle.xml
@@ -165,7 +165,7 @@
       <property name="allowedAbbreviationLength" value="5"/>
       <property name="allowedAbbreviations" value="XML,URL,UUID,JSONB,ISBN,ISSN,ID,ZDB,IIIF,DRM,IO,DZP,DC,DBMDZ,CMS,IT"/> <!-- DBMDZ modified -->
     </module>
-    <module name="OverloadMethodsDeclarationOrder"/>
+    <!-- <module name="OverloadMethodsDeclarationOrder"/>-->  <!-- DBMDZ removed -->
     <module name="VariableDeclarationUsageDistance">
       <property name="allowedDistance" value="10"/>
     </module>


### PR DESCRIPTION
Problem: Error, if methods of same name not grouped together. After discussions: developers sort methods depending on context different. So deactivate rule.

```
[ERROR] /home/christian/src/gitlab.lrz.de/mdz/workflow/google/file-metadata-collector-job/src/main/java/org/mdz/workflow/filemetadata/model/DefaultErrorsImpl.java:132: Overload methods should not be split. Previous overloaded method located at line '107'. [OverloadMethodsDeclarationOrder]
[ERROR] /home/christian/src/gitlab.lrz.de/mdz/workflow/google/file-metadata-collector-job/src/main/java/org/mdz/workflow/filemetadata/model/DefaultErrorsImpl.java:137: Overload methods should not be split. Previous overloaded method located at line '112'. [OverloadMethodsDeclarationOrder]
[ERROR] /home/christian/src/gitlab.lrz.de/mdz/workflow/google/file-metadata-collector-job/src/main/java/org/mdz/workflow/filemetadata/model/DefaultErrorsImpl.java:144: Overload methods should not be split. Previous overloaded method located at line '127'. [OverloadMethodsDeclarationOrder]
```