### PR TITLE
Add main as new alternative to master for CI

### DIFF
--- a/ci/.gitlab-ci-base.yml
+++ b/ci/.gitlab-ci-base.yml
@@ -105,6 +105,7 @@ publish_snapshot:
   extends: .publish
   only:
     - master
+    - main
   script:
     - if [[ ! "$PROJECT_VERSION" =~ .*SNAPSHOT ]]; then exit 0; fi
     - mvn $MAVEN_CLI_OPTS -T 4 deploy -DskipTests --settings settings.xml


### PR DESCRIPTION
CI builds use the branch name `master` to decide if snapshots should be
published. This works now for `main` too and allows for a smooth
transition to the more inclusive branch name.